### PR TITLE
feat(nvim): update alternate-toggler config for v2 cycle support

### DIFF
--- a/nvim/lua/plugins.lua
+++ b/nvim/lua/plugins.lua
@@ -491,7 +491,26 @@ return {
     config = function()
       require("alternate-toggler").setup {
         alternates = {
-          ["=="] = "!=",
+          -- Defaults
+          { "true", "false" },
+          { "True", "False" },
+          { "TRUE", "FALSE" },
+          { "Yes", "No" },
+          { "YES", "NO" },
+          { "1", "0" },
+          { "<", ">" },
+          { "(", ")" },
+          { "[", "]" },
+          { "{", "}" },
+          { '"', "'" },
+          { '""', "''" },
+          { "+", "-" },
+          { "===", "!==" },
+          { "==", "!=" },
+          { "public", "private", "protected" },
+          -- Logging levels (tracing, log4j, Python logging, etc.)
+          { "trace", "debug", "info", "warn", "error" },
+          { "TRACE", "DEBUG", "INFO", "WARN", "ERROR" },
         },
       }
       vim.keymap.set(

--- a/nvim/lua/rmagatti/goto-preview.lua
+++ b/nvim/lua/rmagatti/goto-preview.lua
@@ -21,6 +21,9 @@ M.setup = function()
     debug = false,
     vim_ui_input = true,
     preview_window_title = { enable = false, position = "left" },
+    references = {
+      provider = "snacks",
+    },
     post_open_hook = function(bufr)
       mapping_fn("H", bufr)
       mapping_fn("J", bufr)


### PR DESCRIPTION
## Summary

- Migrate alternate-toggler config from v1 key-value pair format to v2 list-of-cycles format
- Add logging level cycles: `trace` -> `debug` -> `info` -> `warn` -> `error` (and uppercase variant) for Rust tracing, Python logging, etc.
- Include all built-in defaults since v2 `setup()` with `alternates` fully replaces defaults

Pairs with https://github.com/rmagatti/alternate-toggler/pull/17